### PR TITLE
hotfix(AuthController): RequestHeader -> RequestParam으로 변경

### DIFF
--- a/src/main/java/ddd/caffeine/ratrip/module/auth/presentation/AuthController.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/auth/presentation/AuthController.java
@@ -8,8 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import ddd.caffeine.ratrip.module.auth.application.AuthService;
@@ -28,7 +28,7 @@ public class AuthController {
 	private final TokenService tokenService;
 
 	@GetMapping("/auth/signin/kakao")
-	public ResponseEntity<SignInResponseDto> signInWithKakao(@RequestHeader("code") String code) {
+	public ResponseEntity<SignInResponseDto> signInWithKakao(@RequestParam("code") String code) {
 		return ResponseEntity.ok(authService.signInWithKakao(code));
 	}
 


### PR DESCRIPTION
### 변경 내용
- 카카오에서 쿼리 파라미터에 데이터를 담겨서 넘겨줘서 `@RequestHeader` 대신 `@RequestParam`으로 변경

### 사용법
- https://kauth.kakao.com/oauth/authorize?client_id=da4befbef8113651e77dbd493809c2e8&response_type=code&redirect_uri=http://127.0.0.1/v1/auth/signin/kakao 에 접속합니다.

![image](https://user-images.githubusercontent.com/62228195/211577299-54c6825d-a308-44ac-a2f3-dcf764f21008.png)
