### PR TITLE
Hotfix/handle additional exception

### DIFF
--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package ddd.caffeine.ratrip.common.exception;
 
 import java.net.BindException;
 
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -60,7 +61,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	/**
 	 * 400 Bad Request
-	 * Spring Validation 에서 발생하는 예외 처리.
+	 * Spring Validation 에서 발생하는 Exception.
 	 *
 	 * @param e BindException
 	 * @return ErrorResponse
@@ -79,7 +80,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	/**
 	 * 400 Bad Request
-	 * JSON 형식이 잘못되었을 때 발생하는 예외. (Postman에서 테스트할 때 Json이 아닌 Text로 보내면 발생)
+	 * JSON 형식이 잘못되었을 때 발생하는 Exception. (Postman에서 테스트할 때 Json이 아닌 Text로 보내면 발생)
 	 *
 	 * @param e HttpMessageNotReadableException
 	 * @return ErrorResponse
@@ -109,6 +110,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		ExceptionResponse response = ExceptionResponse.builder()
 			.httpStatus(HttpStatus.BAD_REQUEST)
 			.errorCode("MISSING_REQUEST_VALUE_EXCEPTION")
+			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
+	/**
+	 * 400 BadRequest
+	 * 파라미터 바인딩 시점에 타입이 맞지 않으면 내부적으로 발생하는 Exception
+	 *
+	 * @param e TypeMismatchException
+	 * @return ErrorResponse
+	 */
+	@ExceptionHandler(TypeMismatchException.class)
+	public ResponseEntity<ExceptionResponse> handleTypeMismatchException(TypeMismatchException e) {
+		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(HttpStatus.BAD_REQUEST)
+			.errorCode("TYPE_MISMATCH_EXCEPTION")
 			.message(e.getMessage())
 			.build();
 

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -93,90 +93,136 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return new ResponseEntity<>(response, response.getHttpStatus());
 	}
 
+	/**
+	 * 요청 경로는 있으나 지원하지 않는 Method인 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleHttpRequestMethodNotSupported(ex, headers, status, request);
 	}
 
+	/**
+	 * 요청의 Content Type을 핸들러가 지원하지 않는 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleHttpMediaTypeNotSupported(ex, headers, status, request);
 	}
 
+	/**
+	 * 핸들러가 Client가 요청한 Type으로 응답을 내려줄 수 없는 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleHttpMediaTypeNotAcceptable(ex, headers, status, request);
 	}
 
+	/**
+	 * 핸들러가 URL에서 기대한 Path Variable을 찾지 못한 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleMissingPathVariable(MissingPathVariableException ex, HttpHeaders headers,
 		HttpStatus status, WebRequest request) {
 		return super.handleMissingPathVariable(ex, headers, status, request);
 	}
 
+	/**
+	 * 핸들러가 기대한 요청 Parameter를 찾지 못한 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleMissingServletRequestParameter(ex, headers, status, request);
 	}
 
+	/**
+	 * 바인딩 예외를 복구할 수 없는 것으로 처리하려는 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleServletRequestBindingException(ServletRequestBindingException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleServletRequestBindingException(ex, headers, status, request);
 	}
 
+	/**
+	 * bean property로 요청 내용을 변경하기 위한 editor 혹은 converter를 찾지 못한 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleConversionNotSupported(ConversionNotSupportedException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleConversionNotSupported(ex, headers, status, request);
 	}
 
+	/**
+	 * bean property로 값을 변경할 때, 핸들러가 예상한 class로 변경할 수 없는 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers,
 		HttpStatus status, WebRequest request) {
 		return super.handleTypeMismatch(ex, headers, status, request);
 	}
 
+	/**
+	 * HttpMessageConverter에서 발생하며 read 메서드가 실패한 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleHttpMessageNotReadable(ex, headers, status, request);
 	}
 
+	/**
+	 * HttpMessageConverter에서 발생하며 write 메서드가 실패한 경우 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleHttpMessageNotWritable(HttpMessageNotWritableException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleHttpMessageNotWritable(ex, headers, status, request);
 	}
 
+	/**
+	 * @RequestBody 사용시 @Valid가 붙은 파라미터에 대해 검증 실패시 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleMethodArgumentNotValid(ex, headers, status, request);
 	}
 
+	/**
+	 * multipart/form-data 요청의 일부가 손실(can’t be found)되었을 때 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleMissingServletRequestPart(MissingServletRequestPartException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
 		return super.handleMissingServletRequestPart(ex, headers, status, request);
 	}
 
+	/**
+	 * @ModelAttribute 사용시 @Valid가 붙은 파라미터에 대해 검증 실패시 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleBindException(BindException ex, HttpHeaders headers, HttpStatus status,
 		WebRequest request) {
 		return super.handleBindException(ex, headers, status, request);
 	}
 
+	/**
+	 * Dispatcher Servlet에서 핸들러를 찾지 못한 경우 기본적으로 404 응답을 내리지만
+	 * Dispatcher Servlet의 throwExceptionIfNoHandlerFound 값이 true인 경우 발생하는 예외
+	 */
 	@Override
-	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers,
+	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders head외ers,
 		HttpStatus status, WebRequest request) {
 		return super.handleNoHandlerFoundException(ex, headers, status, request);
 	}
 
+	/**
+	 * 비동기 요청의 응답시간이 초과될 때 발생하는 예외
+	 */
 	@Override
 	protected ResponseEntity<Object> handleAsyncRequestTimeoutException(AsyncRequestTimeoutException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest webRequest) {

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.net.BindException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestValueException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -89,6 +90,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		ExceptionResponse response = ExceptionResponse.builder()
 			.httpStatus(HttpStatus.BAD_REQUEST)
 			.errorCode("HTTP_MESSAGE_NOT_READABLE_EXCEPTION")
+			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
+	/**
+	 * 400 BadRequest
+	 * RequestParam, RequestPath, RequestPart 등의 필드가 입력되지 않은 경우 발생하는 Exception
+	 *
+	 * @param e MissingRequestValueException
+	 * @return ErrorResponse
+	 */
+	@ExceptionHandler(MissingRequestValueException.class)
+	public ResponseEntity<ExceptionResponse> handleMissingRequestValueException(MissingRequestValueException e) {
+		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(HttpStatus.BAD_REQUEST)
+			.errorCode("MISSING_REQUEST_VALUE_EXCEPTION")
 			.message(e.getMessage())
 			.build();
 

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -34,10 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-	public GlobalExceptionHandler() {
-		super();
-	}
-
 	/**
 	 * BaseException 으로 throw 한 예외들 처리 하는 메서드.
 	 *
@@ -70,6 +66,28 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 			.errorCode("UNEXPECTED_EXCEPTION")
 			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
+	/**
+	 * @param ex      the exception
+	 * @param body    the body for the response
+	 * @param headers the headers for the response
+	 * @param status  the response status
+	 * @param request the current request
+	 * @return
+	 */
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
+		HttpStatus status, WebRequest request) {
+
+		log.error("cause : {}, message : {}", ex.getCause(), ex.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(status)
+			.errorCode(ex.getClass().getSimpleName())
+			.message(ex.getMessage())
 			.build();
 
 		return new ResponseEntity<>(response, response.getHttpStatus());
@@ -163,12 +181,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	protected ResponseEntity<Object> handleAsyncRequestTimeoutException(AsyncRequestTimeoutException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest webRequest) {
 		return super.handleAsyncRequestTimeoutException(ex, headers, status, webRequest);
-	}
-
-	@Override
-	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
-		HttpStatus status, WebRequest request) {
-		return super.handleExceptionInternal(ex, body, headers, status, request);
 	}
 }
 

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -215,7 +215,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	 * Dispatcher Servlet의 throwExceptionIfNoHandlerFound 값이 true인 경우 발생하는 예외
 	 */
 	@Override
-	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders head외ers,
+	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers,
 		HttpStatus status, WebRequest request) {
 		return super.handleNoHandlerFoundException(ex, headers, status, request);
 	}

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.net.BindException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -69,6 +70,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		ExceptionResponse response = ExceptionResponse.builder()
 			.httpStatus(HttpStatus.BAD_REQUEST)
 			.errorCode("BIND_EXCEPTION")
+			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
+	/**
+	 * 400 Bad Request
+	 * JSON 형식이 잘못되었을 때 발생하는 예외. (Postman에서 테스트할 때 Json이 아닌 Text로 보내면 발생)
+	 *
+	 * @param e HttpMessageNotReadableException
+	 * @return ErrorResponse
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(HttpStatus.BAD_REQUEST)
+			.errorCode("HTTP_MESSAGE_NOT_READABLE_EXCEPTION")
 			.message(e.getMessage())
 			.build();
 

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -38,6 +38,43 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		super();
 	}
 
+	/**
+	 * BaseException 으로 throw 한 예외들 처리 하는 메서드.
+	 *
+	 * @param e BaseException
+	 * @return ErrorResponse
+	 */
+	@ExceptionHandler(BaseException.class)
+	protected ResponseEntity<ExceptionResponse> handleExpectedException(BaseException e) {
+		log.error("code : {}, message : {}", e.getErrorCode(), e.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(e.getHttpStatus())
+			.errorCode(e.getErrorCode())
+			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
+	/**
+	 * 예상하지 못한 예외들 처리.
+	 * 즉 throw 하지 못한 예외들. Runtime 중에 발생하는 모든 예외들 처리.
+	 *
+	 * @param e RuntimeException
+	 * @return ErrorResponse
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	protected ResponseEntity<ExceptionResponse> handleUnexpectedException(RuntimeException e) {
+		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+			.errorCode("UNEXPECTED_EXCEPTION")
+			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
 	@Override
 	protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
 		HttpHeaders headers, HttpStatus status, WebRequest request) {
@@ -132,43 +169,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
 		HttpStatus status, WebRequest request) {
 		return super.handleExceptionInternal(ex, body, headers, status, request);
-	}
-
-	/**
-	 * BaseException 으로 throw 한 예외들 처리 하는 메서드.
-	 *
-	 * @param e BaseException
-	 * @return ErrorResponse
-	 */
-	@ExceptionHandler(BaseException.class)
-	public ResponseEntity<ExceptionResponse> handleExpectedException(BaseException e) {
-		log.error("code : {}, message : {}", e.getErrorCode(), e.getMessage());
-		ExceptionResponse response = ExceptionResponse.builder()
-			.httpStatus(e.getHttpStatus())
-			.errorCode(e.getErrorCode())
-			.message(e.getMessage())
-			.build();
-
-		return new ResponseEntity<>(response, response.getHttpStatus());
-	}
-
-	/**
-	 * 예상하지 못한 예외들 처리.
-	 * 즉 throw 하지 못한 예외들. Runtime 중에 발생하는 모든 예외들 처리.
-	 *
-	 * @param e RuntimeException
-	 * @return ErrorResponse
-	 */
-	@ExceptionHandler(RuntimeException.class)
-	public ResponseEntity<ExceptionResponse> handleUnexpectedException(RuntimeException e) {
-		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
-		ExceptionResponse response = ExceptionResponse.builder()
-			.httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-			.errorCode("UNEXPECTED_EXCEPTION")
-			.message(e.getMessage())
-			.build();
-
-		return new ResponseEntity<>(response, response.getHttpStatus());
 	}
 }
 

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,7 @@
 package ddd.caffeine.ratrip.common.exception;
 
-import java.net.BindException;
-
-import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.web.bind.MissingRequestValueException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -53,82 +48,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		ExceptionResponse response = ExceptionResponse.builder()
 			.httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 			.errorCode("UNEXPECTED_EXCEPTION")
-			.message(e.getMessage())
-			.build();
-
-		return new ResponseEntity<>(response, response.getHttpStatus());
-	}
-
-	/**
-	 * 400 Bad Request
-	 * Spring Validation 에서 발생하는 Exception.
-	 *
-	 * @param e BindException
-	 * @return ErrorResponse
-	 */
-	@ExceptionHandler(BindException.class)
-	public ResponseEntity<ExceptionResponse> handleBindException(BindException e) {
-		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
-		ExceptionResponse response = ExceptionResponse.builder()
-			.httpStatus(HttpStatus.BAD_REQUEST)
-			.errorCode("BIND_EXCEPTION")
-			.message(e.getMessage())
-			.build();
-
-		return new ResponseEntity<>(response, response.getHttpStatus());
-	}
-
-	/**
-	 * 400 Bad Request
-	 * JSON 형식이 잘못되었을 때 발생하는 Exception. (Postman에서 테스트할 때 Json이 아닌 Text로 보내면 발생)
-	 *
-	 * @param e HttpMessageNotReadableException
-	 * @return ErrorResponse
-	 */
-	@ExceptionHandler(HttpMessageNotReadableException.class)
-	public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
-		ExceptionResponse response = ExceptionResponse.builder()
-			.httpStatus(HttpStatus.BAD_REQUEST)
-			.errorCode("HTTP_MESSAGE_NOT_READABLE_EXCEPTION")
-			.message(e.getMessage())
-			.build();
-
-		return new ResponseEntity<>(response, response.getHttpStatus());
-	}
-
-	/**
-	 * 400 BadRequest
-	 * RequestParam, RequestPath, RequestPart 등의 필드가 입력되지 않은 경우 발생하는 Exception
-	 *
-	 * @param e MissingRequestValueException
-	 * @return ErrorResponse
-	 */
-	@ExceptionHandler(MissingRequestValueException.class)
-	public ResponseEntity<ExceptionResponse> handleMissingRequestValueException(MissingRequestValueException e) {
-		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
-		ExceptionResponse response = ExceptionResponse.builder()
-			.httpStatus(HttpStatus.BAD_REQUEST)
-			.errorCode("MISSING_REQUEST_VALUE_EXCEPTION")
-			.message(e.getMessage())
-			.build();
-
-		return new ResponseEntity<>(response, response.getHttpStatus());
-	}
-
-	/**
-	 * 400 BadRequest
-	 * 파라미터 바인딩 시점에 타입이 맞지 않으면 내부적으로 발생하는 Exception
-	 *
-	 * @param e TypeMismatchException
-	 * @return ErrorResponse
-	 */
-	@ExceptionHandler(TypeMismatchException.class)
-	public ResponseEntity<ExceptionResponse> handleTypeMismatchException(TypeMismatchException e) {
-		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
-		ExceptionResponse response = ExceptionResponse.builder()
-			.httpStatus(HttpStatus.BAD_REQUEST)
-			.errorCode("TYPE_MISMATCH_EXCEPTION")
 			.message(e.getMessage())
 			.build();
 

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,26 @@
 package ddd.caffeine.ratrip.common.exception;
 
+import org.springframework.beans.ConversionNotSupportedException;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +33,106 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	public GlobalExceptionHandler() {
+		super();
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleHttpRequestMethodNotSupported(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleHttpMediaTypeNotSupported(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleHttpMediaTypeNotAcceptable(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMissingPathVariable(MissingPathVariableException ex, HttpHeaders headers,
+		HttpStatus status, WebRequest request) {
+		return super.handleMissingPathVariable(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleMissingServletRequestParameter(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleServletRequestBindingException(ServletRequestBindingException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleServletRequestBindingException(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleConversionNotSupported(ConversionNotSupportedException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleConversionNotSupported(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers,
+		HttpStatus status, WebRequest request) {
+		return super.handleTypeMismatch(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleHttpMessageNotReadable(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMessageNotWritable(HttpMessageNotWritableException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleHttpMessageNotWritable(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleMethodArgumentNotValid(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMissingServletRequestPart(MissingServletRequestPartException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		return super.handleMissingServletRequestPart(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleBindException(BindException ex, HttpHeaders headers, HttpStatus status,
+		WebRequest request) {
+		return super.handleBindException(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers,
+		HttpStatus status, WebRequest request) {
+		return super.handleNoHandlerFoundException(ex, headers, status, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleAsyncRequestTimeoutException(AsyncRequestTimeoutException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest webRequest) {
+		return super.handleAsyncRequestTimeoutException(ex, headers, status, webRequest);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
+		HttpStatus status, WebRequest request) {
+		return super.handleExceptionInternal(ex, body, headers, status, request);
+	}
 
 	/**
 	 * BaseException 으로 throw 한 예외들 처리 하는 메서드.

--- a/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package ddd.caffeine.ratrip.common.exception;
 
+import java.net.BindException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -32,7 +34,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.message(e.getMessage())
 			.build();
 
-		return new ResponseEntity(response, response.getHttpStatus());
+		return new ResponseEntity<>(response, response.getHttpStatus());
 	}
 
 	/**
@@ -51,7 +53,26 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.message(e.getMessage())
 			.build();
 
-		return new ResponseEntity(response, response.getHttpStatus());
+		return new ResponseEntity<>(response, response.getHttpStatus());
+	}
+
+	/**
+	 * 400 Bad Request
+	 * Spring Validation 에서 발생하는 예외 처리.
+	 *
+	 * @param e BindException
+	 * @return ErrorResponse
+	 */
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ExceptionResponse> handleBindException(BindException e) {
+		log.error("cause : {}, message : {}", e.getCause(), e.getMessage());
+		ExceptionResponse response = ExceptionResponse.builder()
+			.httpStatus(HttpStatus.BAD_REQUEST)
+			.errorCode("BIND_EXCEPTION")
+			.message(e.getMessage())
+			.build();
+
+		return new ResponseEntity<>(response, response.getHttpStatus());
 	}
 }
 


### PR DESCRIPTION
### 문제 상황
- Postman으로 테스트를 진행하면서 `Status Code`는 400이 떨어졌지만 응답 바디에는 아무것도 나오지 않는 문제를 발견했습니다.
- `GlobalExceptionHandler`에 문제가 있는 것이라 추측하였고 새로운 프로젝트를 생성하여 동일한 상황을 재현해 본 결과, 이를 확신할 수 있었습니다.


### 결과
- `TypeMismatchException`, `BindException` 등 기존 잡지 못한 예외들을 잡을 수 있습니다.

### 예시

- `Request Param`에 넣어야 할 `code`를 `Request Header`에 넣어서 요청을 보냈을 경우 예외 상황
![image](https://user-images.githubusercontent.com/62228195/212347036-cf37806f-bf15-40a9-884d-8b37a800671d.png)

- `GET`이 아닌 `POST`로 요청을 보냈을 경우 예외 상황
![image](https://user-images.githubusercontent.com/62228195/212347199-a6e1757d-bec7-4356-96f4-490a2caaaa75.png)



### PS
- 지원님 덕분에 `ResponseEntityExceptionHandler`를 알게 되어 손쉽게 예외 처리를 할 수 있었습니다 :) 좋은 정보 감사합니다!