### PR TITLE
Feat/use security context holder

### DIFF
--- a/src/main/java/ddd/caffeine/ratrip/common/exception/domain/UserException.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/exception/domain/UserException.java
@@ -1,0 +1,14 @@
+package ddd.caffeine.ratrip.common.exception.domain;
+
+import ddd.caffeine.ratrip.common.exception.BaseException;
+import ddd.caffeine.ratrip.common.exception.ExceptionInformation;
+
+public class UserException extends BaseException {
+	public UserException(int status, String errorCode, String message) {
+		super(status, errorCode, message);
+	}
+
+	public UserException(ExceptionInformation information) {
+		super(information);
+	}
+}

--- a/src/main/java/ddd/caffeine/ratrip/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/filter/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-	private static final List<String> allowList = List.of("/auth", "/swagger-ui", "/api-docs", "/health-check");
+	private static final List<String> ALLOW_LIST = List.of("/auth", "/swagger-ui", "/api-docs", "/health-check");
 	private final JwtUtil jwtUtil;
 
 	@Override
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	private boolean isAllowList(String requestURI) {
-		return allowList.stream().anyMatch(requestURI::contains);
+		return ALLOW_LIST.stream().anyMatch(requestURI::contains);
 	}
 
 	private UUID validateHeaderAndGetUserId(String bearerToken) {

--- a/src/main/java/ddd/caffeine/ratrip/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/filter/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-	private static final List<String> whitelist = List.of("/auth", "/swagger-ui", "/api-docs", "/health-check");
+	private static final List<String> allowList = List.of("/auth", "/swagger-ui", "/api-docs", "/health-check");
 	private final JwtUtil jwtUtil;
 
 	@Override
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	private boolean isWhiteList(String requestURI) {
-		return whitelist.stream().anyMatch(requestURI::contains);
+		return allowList.stream().anyMatch(requestURI::contains);
 	}
 
 	private UUID validateHeaderAndGetUserId(String bearerToken) {

--- a/src/main/java/ddd/caffeine/ratrip/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/filter/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		if (!isWhiteList(request.getRequestURI())) {
+		if (!isAllowList(request.getRequestURI())) {
 			String bearerToken = request.getHeader(AUTHORIZATION_HEADER_PREFIX);
 			UUID userId = validateHeaderAndGetUserId(bearerToken);
 			setAuthentication(userId);
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
-	private boolean isWhiteList(String requestURI) {
+	private boolean isAllowList(String requestURI) {
 		return allowList.stream().anyMatch(requestURI::contains);
 	}
 

--- a/src/main/java/ddd/caffeine/ratrip/module/user/application/UserService.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/user/application/UserService.java
@@ -1,10 +1,14 @@
 package ddd.caffeine.ratrip.module.user.application;
 
+import static ddd.caffeine.ratrip.common.exception.ExceptionInformation.*;
+
 import java.util.UUID;
 
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import ddd.caffeine.ratrip.common.exception.domain.UserException;
 import ddd.caffeine.ratrip.module.user.application.dto.SignUpUserDto;
 import ddd.caffeine.ratrip.module.user.domain.SocialInfo;
 import ddd.caffeine.ratrip.module.user.domain.User;
@@ -15,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class UserService {
+public class UserService implements UserDetailsService {
 	private final UserRepository userRepository;
 
 	public UUID findUserIdBySocialIdAndSocialType(SignUpUserDto request) {
@@ -44,5 +48,11 @@ public class UserService {
 				request.getSocialType()));
 
 		return user.getId();
+	}
+
+	@Override
+	public User loadUserByUsername(String userId) {
+		return userRepository.findById(UUID.fromString(userId))
+			.orElseThrow(() -> new UserException(NOT_FOUND_USER_EXCEPTION));
 	}
 }

--- a/src/main/java/ddd/caffeine/ratrip/module/user/domain/User.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/user/domain/User.java
@@ -1,5 +1,6 @@
 package ddd.caffeine.ratrip.module.user.domain;
 
+import java.util.Collection;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -9,6 +10,9 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import ddd.caffeine.ratrip.common.jpa.AuditingTimeEntity;
 import ddd.caffeine.ratrip.common.util.SequentialUUIDGenerator;
@@ -20,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends AuditingTimeEntity {
+public class User extends AuditingTimeEntity implements UserDetails {
 	@Id
 	@Column(columnDefinition = "BINARY(16)")
 	private UUID id;
@@ -60,5 +64,40 @@ public class User extends AuditingTimeEntity {
 			.socialId(socialId)
 			.socialType(socialType)
 			.build();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return null;
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return id.toString();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
 	}
 }

--- a/src/main/java/ddd/caffeine/ratrip/module/user/domain/repository/UserRepository.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/user/domain/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import ddd.caffeine.ratrip.module.user.domain.SocialInfo;
 import ddd.caffeine.ratrip.module.user.domain.User;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, UUID> {
 	User findUserBySocialInfo(SocialInfo socialInfo);
 
 	User findUserById(UUID id); //TEST METHOD

--- a/src/main/java/ddd/caffeine/ratrip/module/user/presentation/UserController.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/user/presentation/UserController.java
@@ -1,11 +1,9 @@
 package ddd.caffeine.ratrip.module.user.presentation;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import ddd.caffeine.ratrip.module.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -14,10 +12,5 @@ public class UserController {
 	@GetMapping("/health-check")
 	public ResponseEntity<String> test() {
 		return ResponseEntity.ok("health check success");
-	}
-
-	@GetMapping("/test")
-	public ResponseEntity<String> test2(@AuthenticationPrincipal User user) {
-		return ResponseEntity.ok("유저 이름 = " + user.getName());
 	}
 }

--- a/src/main/java/ddd/caffeine/ratrip/module/user/presentation/UserController.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/user/presentation/UserController.java
@@ -1,9 +1,11 @@
 package ddd.caffeine.ratrip.module.user.presentation;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import ddd.caffeine.ratrip.module.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -12,5 +14,10 @@ public class UserController {
 	@GetMapping("/health-check")
 	public ResponseEntity<String> test() {
 		return ResponseEntity.ok("health check success");
+	}
+
+	@GetMapping("/test")
+	public ResponseEntity<String> test2(@AuthenticationPrincipal User user) {
+		return ResponseEntity.ok("유저 이름 = " + user.getName());
 	}
 }


### PR DESCRIPTION
### 바뀐점
- Security Context Holder를 통해 userId를 받아오는 기능을 구현하였습니다.

### 사용 방법
- 아래와 같이 User 객체가 필요한 경우 `@AuthenticationPrincipal` 어노테이션을 통해 받아올 수 있습니다.
```java
	@GetMapping("/test")
	public ResponseEntity<String> test2(@AuthenticationPrincipal User user) {
		return ResponseEntity.ok("유저 이름 = " + user.getName());
	}
```

### 테스트
- https://kauth.kakao.com/oauth/authorize?client_id=da4befbef8113651e77dbd493809c2e8&response_type=code&redirect_uri=http://127.0.0.1/v1/auth/signin/kakao 에 접근하여 카카오 로그인을 진행합니다.

- Access token을 복사하여 헤더에 넣은 뒤 /test로 요청을 보냅니다.
<img width="706" alt="image" src="https://user-images.githubusercontent.com/62228195/212609808-45fb5e18-20ca-4965-8e89-a82c1e3c0e41.png">
