### PR TITLE
외부 데이터를 통한 장소 조회 로직 변경 

### DIFF
--- a/src/main/java/ddd/caffeine/ratrip/module/place/application/PlaceService.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/place/application/PlaceService.java
@@ -22,6 +22,7 @@ import ddd.caffeine.ratrip.module.place.presentation.dto.PlaceInRegionResponseDt
 import ddd.caffeine.ratrip.module.place.presentation.dto.bookmark.BookmarkAddResponseDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.bookmark.BookmarksResponseDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.detail.PlaceDetailsResponseDto;
+import ddd.caffeine.ratrip.module.place.presentation.dto.detail.PlaceSaveThirdPartyResponseDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.search.PlaceSearchResponseDto;
 import ddd.caffeine.ratrip.module.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -58,22 +59,21 @@ public class PlaceService {
 	}
 
 	@Transactional
-	public PlaceDetailsResponseDto readPlaceDetailsByThirdPartyId(ThirdPartyDetailSearchOption searchOption,
+	public PlaceSaveThirdPartyResponseDto savePlaceByThirdPartyData(ThirdPartyDetailSearchOption searchOption,
 		User user) {
-
 		Optional<Place> optionalPlace = placeRepository.findByKakaoId(searchOption.readThirdPartyId());
 
 		if (optionalPlace.isEmpty()) {
 			Place place = readPlaceEntity(searchOption.readPlaceNameAndAddress());
 			placeRepository.save(place);
-			return new PlaceDetailsResponseDto(place, Boolean.FALSE);
+			return new PlaceSaveThirdPartyResponseDto(place, Boolean.FALSE);
 		}
 
 		Place place = optionalPlace.get();
 		handlePlaceUpdate(place, searchOption.readPlaceNameAndAddress());
 		boolean isBookmarked = bookmarkService.isBookmarked(user, place);
 
-		return new PlaceDetailsResponseDto(place, isBookmarked);
+		return new PlaceSaveThirdPartyResponseDto(place, isBookmarked);
 	}
 
 	@Transactional

--- a/src/main/java/ddd/caffeine/ratrip/module/place/presentation/PlaceController.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/place/presentation/PlaceController.java
@@ -60,7 +60,7 @@ public class PlaceController {
 	@PostMapping
 	public ResponseEntity<PlaceSaveThirdPartyResponseDto> callSavePlaceByThirdPartyData(
 		@Parameter(hidden = true) @AuthenticationPrincipal User user,
-		@RequestBody PlaceDetailsByThirdPartyRequestDto request) {
+		@Valid @RequestBody PlaceDetailsByThirdPartyRequestDto request) {
 
 		PlaceSaveThirdPartyResponseDto response = placeService.savePlaceByThirdPartyData(
 			request.mapByThirdPartyDetailSearchOption(), user);

--- a/src/main/java/ddd/caffeine/ratrip/module/place/presentation/PlaceController.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/place/presentation/PlaceController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +28,7 @@ import ddd.caffeine.ratrip.module.place.presentation.dto.bookmark.BookmarkAddRes
 import ddd.caffeine.ratrip.module.place.presentation.dto.bookmark.BookmarksResponseDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.detail.PlaceDetailsByThirdPartyRequestDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.detail.PlaceDetailsResponseDto;
+import ddd.caffeine.ratrip.module.place.presentation.dto.detail.PlaceSaveThirdPartyResponseDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.search.PlaceSearchRequestDto;
 import ddd.caffeine.ratrip.module.place.presentation.dto.search.PlaceSearchResponseDto;
 import ddd.caffeine.ratrip.module.user.domain.User;
@@ -54,13 +56,13 @@ public class PlaceController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "카카오 정보를 통한 장소 상세 읽기 API")
-	@GetMapping("third-party")
-	public ResponseEntity<PlaceDetailsResponseDto> callPlaceDetailsApiByThirdPartyId(
+	@Operation(summary = "카카오 정보를 통한 장소 저장 및 업데이트 API")
+	@PostMapping
+	public ResponseEntity<PlaceSaveThirdPartyResponseDto> callSavePlaceByThirdPartyData(
 		@Parameter(hidden = true) @AuthenticationPrincipal User user,
-		@Valid @ModelAttribute PlaceDetailsByThirdPartyRequestDto request) {
+		@RequestBody PlaceDetailsByThirdPartyRequestDto request) {
 
-		PlaceDetailsResponseDto response = placeService.readPlaceDetailsByThirdPartyId(
+		PlaceSaveThirdPartyResponseDto response = placeService.savePlaceByThirdPartyData(
 			request.mapByThirdPartyDetailSearchOption(), user);
 
 		return ResponseEntity.ok(response);

--- a/src/main/java/ddd/caffeine/ratrip/module/place/presentation/dto/detail/PlaceSaveThirdPartyResponseDto.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/place/presentation/dto/detail/PlaceSaveThirdPartyResponseDto.java
@@ -10,31 +10,23 @@ import lombok.Getter;
  * @Todo : 프론트 및 디자인분들과 해당 필드 상의
  */
 @Getter
-public class PlaceDetailsResponseDto {
-
+public class PlaceSaveThirdPartyResponseDto {
 	private UUID id;
-	private String kakaoId;
 	private String name;
 	private String category;
 	private String address;
 	private Location location;
-	private String imageLink;
-	private String additionalInfoLink;
 	private String telephone;
-
 	private boolean isUpdated;
 	private boolean isBookMarked;
 
-	public PlaceDetailsResponseDto(Place place, boolean isBookMarked) {
+	public PlaceSaveThirdPartyResponseDto(Place place, boolean isBookMarked) {
 		this.id = place.getId();
-		this.kakaoId = place.getKakaoId();
 		this.name = place.getName();
 		this.category = place.getCategory().name();
 		this.address = place.getAddress().toString();
 		this.location = place.getLocation();
 		this.isUpdated = place.isUpdated();
-		this.imageLink = place.getImageLink();
-		this.additionalInfoLink = place.getAdditionalInfoLink();
 		this.telephone = place.getTelephone();
 		this.isBookMarked = isBookMarked;
 	}

--- a/src/test/java/ddd/caffeine/ratrip/module/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/ddd/caffeine/ratrip/module/place/presentation/PlaceControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ddd.caffeine.ratrip.module.place.application.PlaceService;
+import ddd.caffeine.ratrip.module.place.presentation.dto.detail.PlaceDetailsByThirdPartyRequestDto;
 
 @MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(controllers = PlaceController.class,
@@ -39,15 +40,20 @@ class PlaceControllerTest {
 	@DisplayName("custom 어노테이션 Number 정상 동작 테스트")
 	void customAnnotationNumberTest() throws Exception {
 		//given
-		String baseURI = "/v1/places/third-party/";
-		String thirdPartyId = "?thirdPartyId=12345";
-		String placeName = "&placeName=지원이네 집";
-		String address = "&address=서울특별시 서초구 양재동 16-10";
+		String baseURI = "/v1/places/";
+		String thirdPartyId = "12345";
+		String placeName = "지원이네 집";
+		String address = "서울특별시 서초구 양재동 16-10";
 
-		String URI = baseURI + thirdPartyId + placeName + address;
+		PlaceDetailsByThirdPartyRequestDto request = new PlaceDetailsByThirdPartyRequestDto(
+			thirdPartyId, placeName, address
+		);
+
+		String content = mapper.writeValueAsString(request);
 
 		//when
-		ResultActions actions = mockMvc.perform(get(URI)
+		ResultActions actions = mockMvc.perform(post(baseURI)
+			.content(content)
 			.contentType(MediaType.APPLICATION_JSON_VALUE));
 		// then
 		actions
@@ -59,16 +65,22 @@ class PlaceControllerTest {
 	@ValueSource(strings = {"", "134숫자", "?234"})
 	void customAnnotationNumberReturnExceptionTest(String id) throws Exception {
 		//given
-		String baseURI = "/v1/places/third-party/";
-		String thirdPartyId = "?thirdPartyId=" + id;
-		String placeName = "&placeName=지원이네 집";
-		String address = "&address=서울특별시 서초구 양재동 16-10";
+		String baseURI = "/v1/places/";
+		String thirdPartyId = id;
+		String placeName = "지원이네 집";
+		String address = "서울특별시 서초구 양재동 16-10";
 
-		String URI = baseURI + thirdPartyId + placeName + address;
+		PlaceDetailsByThirdPartyRequestDto request = new PlaceDetailsByThirdPartyRequestDto(
+			thirdPartyId, placeName, address
+		);
+
+		String content = mapper.writeValueAsString(request);
 
 		//when
-		ResultActions actions = mockMvc.perform(get(URI)
+		ResultActions actions = mockMvc.perform(post(baseURI)
+			.content(content)
 			.contentType(MediaType.APPLICATION_JSON_VALUE));
+
 		// then
 		actions
 			.andExpect(status().is4xxClientError());


### PR DESCRIPTION
## 배경
- **기존의 외부 데이터를 통해 장소 조회의 주 기능은 장소 저장 및 업데이트 확인 이였습니다.**
- Map 을 통해 장소의 북마크 정보를 받아오는 과정에서, 장소의 UUID 또는 카카오 ID 으로 북마크 조회 가 필요했습니다.

## 개선
- 해당 API 의 역할에 맞는 로직으로 변경 되었습니다.
-  장소의 기본키 값을 얻어옴으로 좀 더 확장성 있는 설계가 가능해졌습니다.

## 변경
- 외부데이터를 통한 장소 상세 읽기 -> 외부데이터를 통한 장소 저장 및 업데이트 로 변경되었습니다.

## 테스트 
- 예외 상황에 대한 동작 테스트는 구현한 테스트 코드를 통해 확인 하실수 있습니다.
- PostMan 을 통해 테스트 할 수 있습니다.
<img width="1001" alt="스크린샷 2023-01-25 오후 12 02 58" src="https://user-images.githubusercontent.com/80501465/214471686-fabb5869-8c68-48be-b435-5bb8cee2cae6.png">

> 정상 동작 테스트
