### PR TITLE
fix(SecurityConfiguration): ddd-web2-map에서 오는 요청은 cors 문제 생기지 않도록 패턴 변경

### DIFF
--- a/src/main/java/ddd/caffeine/ratrip/common/configuration/SecurityConfiguration.java
+++ b/src/main/java/ddd/caffeine/ratrip/common/configuration/SecurityConfiguration.java
@@ -49,7 +49,7 @@ public class SecurityConfiguration {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 
-		configuration.addAllowedOriginPattern("https://ddd-web2-map.web.app");
+		configuration.addAllowedOriginPattern("https://ddd-web2-map");
 		configuration.addAllowedHeader("*");
 		configuration.addAllowedMethod("*");
 		configuration.setAllowCredentials(true);


### PR DESCRIPTION
### 변경 사항
- 클라이언트의 요청으로 인해 `https://ddd-web2-map`에서 오는 요청은 cors 문제 생기지 않도록 `allowOriginPattern`을 수정하였습니다 :)