### PR TITLE
delete(PlaceFeignService): 불필요한 Radius 옵션 삭제

### DIFF
--- a/src/main/java/ddd/caffeine/ratrip/module/place/application/PlaceFeignService.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/place/application/PlaceFeignService.java
@@ -53,10 +53,9 @@ public class PlaceFeignService {
 		final String KAKAO_API_KEY = secretKeyManager.getKakaoRestApiKey();
 
 		final String KAKAO_REQUEST_HEADER = "KakaoAK " + KAKAO_API_KEY;
-		final int PLACE_RADIUS = 20000;
 
 		return kakaoFeignClient.readPlacesByKeywordInRadius(
-			KAKAO_REQUEST_HEADER, option.getKeyword(), option.readLatitude(), option.readLongitude(), PLACE_RADIUS,
+			KAKAO_REQUEST_HEADER, option.getKeyword(), option.readLatitude(), option.readLongitude(),
 			option.getPage());
 	}
 

--- a/src/main/java/ddd/caffeine/ratrip/module/place/feign/kakao/KakaoFeignClient.java
+++ b/src/main/java/ddd/caffeine/ratrip/module/place/feign/kakao/KakaoFeignClient.java
@@ -17,7 +17,6 @@ public interface KakaoFeignClient {
 		@RequestParam("query") String query,
 		@RequestParam("y") String latitude,
 		@RequestParam("x") String longitude,
-		@RequestParam("radius") int radius,
 		@RequestParam("page") int page
 	);
 


### PR DESCRIPTION
## 문제점
- 불필요한 Radius 옵션으로 인해 서울에서 부산 여행을 계획하기 위해 "부산 해운대"를 검색하면 검색 결과가 나오지 않는 문제 발생

## 변경 사항
- Radius 설정 삭제